### PR TITLE
Fix for spaced seed iterator

### DIFF
--- a/nthash.hpp
+++ b/nthash.hpp
@@ -591,9 +591,11 @@ inline bool NTMS64(const char *kmerSeq, const std::vector<std::vector<unsigned> 
     
     for(unsigned j=0; j<m; j++) {
         uint64_t fsVal=fhVal, rsVal=rhVal;
-        for(std::vector<unsigned>::const_iterator i=seedSeq[j].begin(); i!=seedSeq[j].end(); ++i) {
-            fsVal ^= (msTab31l[(unsigned char)kmerSeq[*i]][(k-1-*i)%31] | msTab33r[(unsigned char)kmerSeq[*i]][(k-1-*i)%33]);
-            rsVal ^= (msTab31l[(unsigned char)kmerSeq[*i]&cpOff][*i%31] | msTab33r[(unsigned char)kmerSeq[*i]&cpOff][*i%33]);
+        for(unsigned i=0; i<k; i++) {
+            if (!seedSeq[j][i]) {
+                fsVal ^= (msTab31l[(unsigned char)kmerSeq[i]][(k-1-i)%31] | msTab33r[(unsigned char)kmerSeq[i]][(k-1-i)%33]);
+                rsVal ^= (msTab31l[(unsigned char)kmerSeq[i]&cpOff][i%31] | msTab33r[(unsigned char)kmerSeq[i]&cpOff][i%33]);
+            }
         }
         hStn[j] = rsVal<fsVal;
         hVal[j] = hStn[j]? rsVal : fsVal;
@@ -607,9 +609,11 @@ inline void NTMS64(const char *kmerSeq, const std::vector<std::vector<unsigned> 
     rhVal = NTR64(rhVal,k,charOut,charIn);
     for(unsigned j=0; j<m; j++) {
         uint64_t fsVal=fhVal, rsVal=rhVal;
-        for(std::vector<unsigned>::const_iterator i=seedSeq[j].begin(); i!=seedSeq[j].end(); ++i) {
-            fsVal ^= (msTab31l[(unsigned char)kmerSeq[*i]][(k-1-*i)%31] | msTab33r[(unsigned char)kmerSeq[*i]][(k-1-*i)%33]);
-            rsVal ^= (msTab31l[(unsigned char)kmerSeq[*i]&cpOff][*i%31] | msTab33r[(unsigned char)kmerSeq[*i]&cpOff][*i%33]);;
+        for(unsigned i=0; i<k; i++) {
+            if (!seedSeq[j][i]) {
+                fsVal ^= (msTab31l[(unsigned char)kmerSeq[i]][(k-1-i)%31] | msTab33r[(unsigned char)kmerSeq[i]][(k-1-i)%33]);
+                rsVal ^= (msTab31l[(unsigned char)kmerSeq[i]&cpOff][i%31] | msTab33r[(unsigned char)kmerSeq[i]&cpOff][i%33]);
+            }
         }
         hStn[j] = rsVal<fsVal;
         hVal[j] = hStn[j]? rsVal : fsVal;
@@ -638,9 +642,11 @@ inline bool NTMSM64(const char *kmerSeq, const std::vector<std::vector<unsigned>
 
     for(unsigned j=0; j<m; j++) {
         uint64_t fsVal=fhVal, rsVal=rhVal;
-        for(std::vector<unsigned>::const_iterator i=seedSeq[j].begin(); i!=seedSeq[j].end(); ++i) {
-            fsVal ^= (msTab31l[(unsigned char)kmerSeq[*i]][(k-1-*i)%31] | msTab33r[(unsigned char)kmerSeq[*i]][(k-1-*i)%33]);
-            rsVal ^= (msTab31l[(unsigned char)kmerSeq[*i]&cpOff][*i%31] | msTab33r[(unsigned char)kmerSeq[*i]&cpOff][*i%33]);
+        for(unsigned i=0; i<k; i++) {
+            if (!seedSeq[j][i]) {
+                fsVal ^= (msTab31l[(unsigned char)kmerSeq[i]][(k-1-i)%31] | msTab33r[(unsigned char)kmerSeq[i]][(k-1-i)%33]);
+                rsVal ^= (msTab31l[(unsigned char)kmerSeq[i]&cpOff][i%31] | msTab33r[(unsigned char)kmerSeq[i]&cpOff][i%33]);
+            }
         }
         hStn[j * m2] = rsVal<fsVal;
         hVal[j * m2] = hStn[j * m2]? rsVal : fsVal;
@@ -662,9 +668,11 @@ const unsigned k, const unsigned m, const unsigned m2, uint64_t& fhVal, uint64_t
     rhVal = NTR64(rhVal,k,charOut,charIn);
     for(unsigned j=0; j<m; j++) {
         uint64_t fsVal=fhVal, rsVal=rhVal;
-        for(std::vector<unsigned>::const_iterator i=seedSeq[j].begin(); i!=seedSeq[j].end(); ++i) {
-            fsVal ^= (msTab31l[(unsigned char)kmerSeq[*i]][(k-1-*i)%31] | msTab33r[(unsigned char)kmerSeq[*i]][(k-1-*i)%33]);
-            rsVal ^= (msTab31l[(unsigned char)kmerSeq[*i]&cpOff][*i%31] | msTab33r[(unsigned char)kmerSeq[*i]&cpOff][*i%33]);
+        for(unsigned i=0; i<k; i++) {
+            if (!seedSeq[j][i]) {
+                fsVal ^= (msTab31l[(unsigned char)kmerSeq[i]][(k-1-i)%31] | msTab33r[(unsigned char)kmerSeq[i]][(k-1-i)%33]);
+                rsVal ^= (msTab31l[(unsigned char)kmerSeq[i]&cpOff][i%31] | msTab33r[(unsigned char)kmerSeq[i]&cpOff][i%33]);
+            }
         }
         hStn[j * m2] = rsVal<fsVal;
         hVal[j * m2] = hStn[j * m2]? rsVal : fsVal;


### PR DESCRIPTION
I think there is an error in the iterator used in some of the (multi)spaced seed functions, which takes the value of the seed (0/1) rather than its position and a conditional test on its value. Copying the code used in `maskHash` and `NTS64` fixes this.