### PR TITLE
fix inconsistent canonical hash values for k%4==0

### DIFF
--- a/nthash.hpp
+++ b/nthash.hpp
@@ -401,6 +401,9 @@ inline uint64_t NTF64(const char * kmerSeq, const unsigned k) {
         hVal ^= tetramerTab[tetramerLoc];
     }
 	unsigned remainder = k % 4;
+    if (remainder == 0) {
+        return hVal;
+    }
     hVal = rolx(hVal, remainder);
     hVal = swapxbits033(hVal, remainder);
 	if (remainder == 3) {


### PR DESCRIPTION
#39 

Early exit in `NTF64` when k%4==0.

The problem and the fix is described in the issue above.
